### PR TITLE
Feat: Scrape preview image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "firebase": "^11.0.1",
         "next": "15.0.1",
+        "open-graph-scraper": "^6.8.2",
         "react": "19.0.0-rc-69d4b800-20241021",
         "react-dom": "19.0.0-rc-69d4b800-20241021"
       },
@@ -1834,6 +1835,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1930,6 +1937,54 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.0.0.tgz",
+      "integrity": "sha512-xVgPpulCooDjY6zH4m9YW3jbkaBe3FKIAvF5sj5t7aBNsVl2ljIE+xwJ4iNgiDZHFQvNIpjdKdVOQvvk5ZfxbQ==",
+      "license": "MIT"
+    },
+    "node_modules/cheerio": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2005,6 +2060,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -2142,11 +2225,79 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
+      "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.17.1",
@@ -2159,6 +2310,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -3252,10 +3415,41 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
       "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/idb": {
       "version": "7.1.1",
@@ -3998,6 +4192,18 @@
         }
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4118,6 +4324,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/open-graph-scraper": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/open-graph-scraper/-/open-graph-scraper-6.8.2.tgz",
+      "integrity": "sha512-Ht3k+bhEfLCojwka13xN+9B6LANJBcANI9TZ28KNBMBlK/dp/ooEblDyzj25RQVzXWUAK4UDlQQHU4hFmCnClg==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.0.0",
+        "cheerio": "^1.0.0-rc.12",
+        "iconv-lite": "^0.6.3",
+        "undici": "^6.19.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4175,6 +4396,43 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -4544,6 +4802,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.25.0-rc-69d4b800-20241021",
@@ -5074,6 +5338,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.20.1.tgz",
+      "integrity": "sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -5107,6 +5380,27 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "firebase": "^11.0.1",
     "next": "15.0.1",
+    "open-graph-scraper": "^6.8.2",
     "react": "19.0.0-rc-69d4b800-20241021",
     "react-dom": "19.0.0-rc-69d4b800-20241021"
   },

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -106,7 +106,10 @@ export const App = () => {
       {/* The .map function takes an array in one format and maps each element onto a different format.
           In this case, we take elements that are simple objects, and transform each one into a JSX element. */}
       {Object.entries(seedlings).map(
-        ([key, { x, y, title, url, size, color, comments, reactions }]) => {
+        ([
+          key,
+          { x, y, title, url, imgSrc, size, color, comments, reactions },
+        ]) => {
           // We have to define a unique key for each element in the resulting array in order for React to keep
           // track of them properly
           return (
@@ -118,16 +121,18 @@ export const App = () => {
               y={y}
               size={size}
               color={color}
+              imgSrc={imgSrc}
               setPosition={({ x: newX, y: newY }) => {
                 const newSeedling = {
                   x: newX,
                   y: newY,
                   title,
                   url,
+                  imgSrc,
                   size,
                   color,
-                  ...(comments ? {comments} : {}),
-                  ...(reactions ? {reactions} : {}),
+                  ...(comments ? { comments } : {}),
+                  ...(reactions ? { reactions } : {}),
                 };
                 // This seems cumbersome but is necessary because if we simply mutate one of the
                 // elements of newSeedlings, React won't notice that it's been updated and therefore

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -9,6 +9,9 @@ import { SeedlingBubble } from "./SeedlingBubble";
 import { BubbleModal } from "./BubbleModal";
 import styles from "./App.module.css";
 
+const COMMENTS_WEIGHT = 50;
+const REACTIONS_WEIGHT = 20;
+
 export const App = () => {
   // React uses a concept called "state" to keep track of data that changes over time, instead of using
   // global variables like in P5. This state is local to the particular component it's defined in, in this
@@ -110,6 +113,17 @@ export const App = () => {
           key,
           { x, y, title, url, imgSrc, size, color, comments, reactions },
         ]) => {
+          const numComments = comments ? Object.keys(comments).length : 0;
+          const numReactions = reactions
+            ? Object.keys(reactions).reduce(
+                (acc, cur) => acc + Object.keys(reactions[cur]).length,
+                0
+              )
+            : 0;
+          const adjustedSize =
+            size +
+            numComments * COMMENTS_WEIGHT +
+            numReactions * REACTIONS_WEIGHT;
           // We have to define a unique key for each element in the resulting array in order for React to keep
           // track of them properly
           return (
@@ -119,7 +133,7 @@ export const App = () => {
               url={url}
               x={x}
               y={y}
-              size={size}
+              size={adjustedSize}
               color={color}
               imgSrc={imgSrc}
               setPosition={({ x: newX, y: newY }) => {

--- a/src/components/NewPost.js
+++ b/src/components/NewPost.js
@@ -17,7 +17,6 @@ const NewPost = ({ isOpen, onClose, onSubmit, mousePosition }) => {
     const imgSrc = Array.isArray(ogImageData)
       ? ogImageData?.[0].url
       : ogImageData?.url;
-    console.log({ ogImageData, imgSrc });
     const newSeedling = {
       x: mousePosition.x,
       y: mousePosition.y,

--- a/src/components/NewPost.js
+++ b/src/components/NewPost.js
@@ -8,8 +8,16 @@ const NewPost = ({ isOpen, onClose, onSubmit, mousePosition }) => {
 
   if (!isOpen) return null;
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
+    // Get the Open Graph image data for the URL if it exists.
+    const ogResponse = await fetch(`/api/open-graph?url=${url}`);
+    const ogData = await ogResponse.json();
+    const ogImageData = ogData.ogImage;
+    const imgSrc = Array.isArray(ogImageData)
+      ? ogImageData?.[0].url
+      : ogImageData?.url;
+    console.log({ ogImageData, imgSrc });
     const newSeedling = {
       x: mousePosition.x,
       y: mousePosition.y,
@@ -17,6 +25,7 @@ const NewPost = ({ isOpen, onClose, onSubmit, mousePosition }) => {
       url,
       size: 200, //default size
       color: randomColorFromPalette(),
+      imgSrc,
     };
     onSubmit(newSeedling); // Call the onSubmit function passed from App.js
     setTitle("");

--- a/src/components/SeedlingBubble.js
+++ b/src/components/SeedlingBubble.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import GooEffect from "./GooEffect"; 
+import GooEffect from "./GooEffect";
 import styles from "./SeedlingBubble.module.css";
 
 // This is one bubble defining a seedling on the main app window.
@@ -7,6 +7,7 @@ import styles from "./SeedlingBubble.module.css";
 export const SeedlingBubble = ({
   title,
   url,
+  imgSrc,
   x,
   y,
   size,
@@ -23,7 +24,7 @@ export const SeedlingBubble = ({
   // Otherwise, the code would be run *every time* the component re-renders, which would result int
   // new random colors on every bubble every time the user adds a new bubble.
   useEffect(() => {
-    const newBackground = `radial-gradient(closest-side, ${color} 30%, rgba(0, 0, 0, 0))`; //changed to single color gradient
+    const newBackground = `radial-gradient(closest-side, transparent 40%, ${color} 60%, ${color} 80%, transparent 100%)`; //changed to single color gradient
     setBackground(newBackground);
   }, [color]);
 
@@ -53,26 +54,39 @@ export const SeedlingBubble = ({
   };
 
   return (
-    <><GooEffect /><div
-      // React uses "className" instead of the normal "class" because "class" is already a reserved keyword
-      // in JavaScript with a different meaning.
-      className={styles.seedlingBubble}
-      style={{
-        top: y - size / 2, // We do the extra calculation because CSS is expecting top-left corner
-        left: x - size / 2, // instead of center for <div> elements
-        height: size,
-        width: size,
-        background: background,
-        zIndex: isDragging ? 1000 : "auto", // move bubble to toppest layer when dragged
-        // filter: "url(#goo) blur(10px)", //the goo filter is not working so I commented it out... -md
-      }}
-      onMouseDown={handleMouseDown}
-      onMouseMove={handleMouseMove}
-      onMouseUp={handleMouseUp}
-    >
-      {/* We use the curly braces to inject the props into the JSX output, so that
-      when any of the props change value, the HTML will update or "react" automatically */}
-      {title}
-    </div></>
+    <>
+      <GooEffect />
+      <div
+        // React uses "className" instead of the normal "class" because "class" is already a reserved keyword
+        // in JavaScript with a different meaning.
+        className={styles.seedlingBubble}
+        style={{
+          top: y - size / 2, // We do the extra calculation because CSS is expecting top-left corner
+          left: x - size / 2, // instead of center for <div> elements
+          height: size,
+          width: size,
+          backgroundImage: `url(${imgSrc}`,
+          backgroundPosition: `center center`,
+          backgroundSize: "cover",
+          backgroundClip: "border-box",
+          backgroundRepeat: "no-repeat",
+          zIndex: isDragging ? 1000 : "auto", // move bubble to toppest layer when dragged
+          // filter: "url(#goo) blur(10px)", //the goo filter is not working so I commented it out... -md
+        }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+      >
+        <div
+          className={styles.gradientOutline}
+          style={{
+            background,
+          }}
+        />
+        {/* We use the curly braces to inject the props into the JSX output, so that
+          when any of the props change value, the HTML will update or "react" automatically */}
+        <div className={styles.title}>{title}</div>
+      </div>
+    </>
   );
 };

--- a/src/components/SeedlingBubble.js
+++ b/src/components/SeedlingBubble.js
@@ -55,7 +55,7 @@ export const SeedlingBubble = ({
 
   return (
     <>
-      <GooEffect />
+      {/* <GooEffect /> */}
       <div
         // React uses "className" instead of the normal "class" because "class" is already a reserved keyword
         // in JavaScript with a different meaning.
@@ -67,42 +67,21 @@ export const SeedlingBubble = ({
           width: size,
           backgroundImage: `url(${imgSrc}`,
           zIndex: isDragging ? 1000 : "auto", // move bubble to toppest layer when dragged
+          // filter: "url(#goo) blur(10px)", //the goo filter is not working so I commented it out... -md
         }}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
       >
         <div
-          // React uses "className" instead of the normal "class" because "class" is already a reserved keyword
-          // in JavaScript with a different meaning.
-          className={styles.seedlingBubble}
+          className={styles.gradientOutline}
           style={{
-            top: y - size / 2, // We do the extra calculation because CSS is expecting top-left corner
-            left: x - size / 2, // instead of center for <div> elements
-            height: size,
-            width: size,
-            backgroundImage: `url(${imgSrc}`,
-            backgroundPosition: `center center`,
-            backgroundSize: "cover",
-            backgroundClip: "border-box",
-            backgroundRepeat: "no-repeat",
-            zIndex: isDragging ? 1000 : "auto", // move bubble to toppest layer when dragged
-            // filter: "url(#goo) blur(10px)", //the goo filter is not working so I commented it out... -md
+            background,
           }}
-          onMouseDown={handleMouseDown}
-          onMouseMove={handleMouseMove}
-          onMouseUp={handleMouseUp}
-        >
-          <div
-            className={styles.gradientOutline}
-            style={{
-              background,
-            }}
-          />
-          {/* We use the curly braces to inject the props into the JSX output, so that
+        />
+        {/* We use the curly braces to inject the props into the JSX output, so that
           when any of the props change value, the HTML will update or "react" automatically */}
-          <div className={styles.title}>{title}</div>
-        </div>
+        <div className={styles.title}>{title}</div>
       </div>
     </>
   );

--- a/src/components/SeedlingBubble.js
+++ b/src/components/SeedlingBubble.js
@@ -66,26 +66,43 @@ export const SeedlingBubble = ({
           height: size,
           width: size,
           backgroundImage: `url(${imgSrc}`,
-          backgroundPosition: `center center`,
-          backgroundSize: "cover",
-          backgroundClip: "border-box",
-          backgroundRepeat: "no-repeat",
           zIndex: isDragging ? 1000 : "auto", // move bubble to toppest layer when dragged
-          // filter: "url(#goo) blur(10px)", //the goo filter is not working so I commented it out... -md
         }}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
       >
         <div
-          className={styles.gradientOutline}
+          // React uses "className" instead of the normal "class" because "class" is already a reserved keyword
+          // in JavaScript with a different meaning.
+          className={styles.seedlingBubble}
           style={{
-            background,
+            top: y - size / 2, // We do the extra calculation because CSS is expecting top-left corner
+            left: x - size / 2, // instead of center for <div> elements
+            height: size,
+            width: size,
+            backgroundImage: `url(${imgSrc}`,
+            backgroundPosition: `center center`,
+            backgroundSize: "cover",
+            backgroundClip: "border-box",
+            backgroundRepeat: "no-repeat",
+            zIndex: isDragging ? 1000 : "auto", // move bubble to toppest layer when dragged
+            // filter: "url(#goo) blur(10px)", //the goo filter is not working so I commented it out... -md
           }}
-        />
-        {/* We use the curly braces to inject the props into the JSX output, so that
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUp}
+        >
+          <div
+            className={styles.gradientOutline}
+            style={{
+              background,
+            }}
+          />
+          {/* We use the curly braces to inject the props into the JSX output, so that
           when any of the props change value, the HTML will update or "react" automatically */}
-        <div className={styles.title}>{title}</div>
+          <div className={styles.title}>{title}</div>
+        </div>
       </div>
     </>
   );

--- a/src/components/SeedlingBubble.module.css
+++ b/src/components/SeedlingBubble.module.css
@@ -14,6 +14,7 @@
   background-size: cover;
   background-clip: border-box;
   background-repeat: no-repeat;
+  transition: all 0.3s ease-in-out;
 }
 
 @keyframes popup {

--- a/src/components/SeedlingBubble.module.css
+++ b/src/components/SeedlingBubble.module.css
@@ -9,6 +9,11 @@
 
   opacity: 0;
   animation: popup 1s ease-out forwards;
+
+  background-position: center center;
+  background-size: cover;
+  background-clip: border-box;
+  background-repeat: no-repeat;
 }
 
 @keyframes popup {
@@ -16,7 +21,7 @@
     transform: scale(0);
     opacity: 0;
   }
-  80%{
+  80% {
     transform: scale(1);
     opacity: 1;
   }

--- a/src/components/SeedlingBubble.module.css
+++ b/src/components/SeedlingBubble.module.css
@@ -14,7 +14,7 @@
   background-size: cover;
   background-clip: border-box;
   background-repeat: no-repeat;
-  transition: all 0.3s ease-in-out;
+  transition: height 0.3s ease-in-out, width 0.3s ease-in-out;
 }
 
 @keyframes popup {

--- a/src/components/SeedlingBubble.module.css
+++ b/src/components/SeedlingBubble.module.css
@@ -30,6 +30,16 @@
   }
 }
 
+.gradientOutline {
+  position: absolute;
+  top: -25%;
+  left: -25%;
+  width: 150%;
+  height: 150%;
+  border-radius: 50%;
+  z-index: 10;
+}
+
 .blurBackground {
   position: absolute;
   top: 0;
@@ -40,11 +50,19 @@
 }
 
 .title {
-  position: relative;
-  z-index: 1;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -10%;
+  z-index: 30;
+  color: black;
   display: flex;
   align-items: center;
   justify-content: center;
   user-select: none;
   pointer-events: none;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 500;
+  font-size: 0.7em;
 }

--- a/src/pages/api/hello.js
+++ b/src/pages/api/hello.js
@@ -1,5 +1,0 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-
-export default function handler(req, res) {
-  res.status(200).json({ name: "John Doe" });
-}

--- a/src/pages/api/open-graph.js
+++ b/src/pages/api/open-graph.js
@@ -1,0 +1,15 @@
+import ogs from "open-graph-scraper";
+
+export default function handler(req, res) {
+  const { url } = req.query;
+  ogs({ url })
+    .then(({ error, result }) => {
+      if (error) {
+        res.status(500).json(result);
+      }
+      res.status(200).json(result);
+    })
+    .catch((e) => {
+      res.status(500).json(e);
+    });
+}


### PR DESCRIPTION
This PR adds the `open-graph-scraper` API endpoint and integrates the front-end against the endpoint to display the preview image for each link bubble.

Also adjusted the gradients a bit to allow the preview image to show through

Lastly, I adjusted the size of the each bubble to show larger depending on the number of comments and reactions it currently has.

<img width="1535" alt="Screenshot 2024-11-05 at 3 01 51 PM" src="https://github.com/user-attachments/assets/3bc67c55-5e5e-4d13-a526-d9bf97303165">
