### PR TITLE
feat: goo effect

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -8,6 +8,7 @@ import NewPost from "./NewPost";
 import { SeedlingBubble } from "./SeedlingBubble";
 import { BubbleModal } from "./BubbleModal";
 import styles from "./App.module.css";
+import GooEffect from "./GooEffect";
 
 const COMMENTS_WEIGHT = 50;
 const REACTIONS_WEIGHT = 20;
@@ -84,6 +85,7 @@ export const App = () => {
     // React uses a language called JSX which is a fancy way of inserting HTML-like language into the middle of
     // JavaScript code. It compiles down into something similar to document.createElement('div').
     <div className={styles.app} onDoubleClick={handleClick}>
+      <GooEffect />
       <Link href="/">
         <Image
           src="/assets/pollinator-logo.svg"
@@ -164,7 +166,44 @@ export const App = () => {
             />
           );
         }
-      )}{" "}
+      )}
+      {/* Shadow copy of all seedlings for the Goo effect */}
+      <div className={styles.gooBubbles}>
+        {Object.entries(seedlings).map(
+          ([
+            key,
+            { x, y, title, url, imgSrc, size, color, comments, reactions },
+          ]) => {
+            const numComments = comments ? Object.keys(comments).length : 0;
+            const numReactions = reactions
+              ? Object.keys(reactions).reduce(
+                  (acc, cur) => acc + Object.keys(reactions[cur]).length,
+                  0
+                )
+              : 0;
+            const adjustedSize =
+              size +
+              numComments * COMMENTS_WEIGHT +
+              numReactions * REACTIONS_WEIGHT;
+            // We have to define a unique key for each element in the resulting array in order for React to keep
+            // track of them properly
+            return (
+              <SeedlingBubble
+                key={key}
+                title={title}
+                url={url}
+                x={x}
+                y={y}
+                size={adjustedSize}
+                color={color}
+                imgSrc={imgSrc}
+                backgroundOnly
+              />
+            );
+          }
+        )}
+      </div>
+
       {/* End of Seedling */}
       {/* seedling info modal */}
       {isModalOpen ? (

--- a/src/components/App.module.css
+++ b/src/components/App.module.css
@@ -13,7 +13,7 @@
     z-index: 20;
     position: relative;
   }
-  
+
   .openInfoButton {
     font-family: "Bricolage Grotesque", sans-serif;
     position: absolute;
@@ -28,8 +28,17 @@
     box-shadow: 0 4px 6px #28a6aa;
     transition: background-color 0.3s;
   }
-  
+
   .openInfoButton:hover {
     background-color: rgb(169, 221, 222); /* Darken on hover */
   }
+}
+
+.gooBubbles {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: -1;
+  filter: url(#goo);
+  opacity: 0.5;
 }

--- a/src/components/GooEffect.js
+++ b/src/components/GooEffect.js
@@ -1,14 +1,21 @@
 const GooEffect = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" style={{ position: "absolute", width: 0, height: 0 }}>
-      <defs>
-        <filter id="goo" x="-50%" y="-50%" width="200%" height="200%">
-          <feGaussianBlur in="SourceGraphic" stdDeviation="10" result="blur" />
-          <feColorMatrix in="blur" mode="matrix" values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 18 -8" result="goo" />
-          <feBlend in="SourceGraphic" in2="goo" />
-        </filter>
-      </defs>
-    </svg>
-  );
-  
-  export default GooEffect;
-  
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    style={{ position: "absolute", width: 0, height: 0 }}
+  >
+    <defs>
+      <filter id="goo" x="-50%" y="-50%" width="200%" height="200%">
+        <feGaussianBlur in="SourceGraphic" stdDeviation="30" result="blur" />
+        <feColorMatrix
+          in="blur"
+          mode="matrix"
+          values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 40 -8"
+          result="goo"
+        />
+        <feBlend in="SourceGraphic" in2="goo" />
+      </filter>
+    </defs>
+  </svg>
+);
+
+export default GooEffect;

--- a/src/components/SeedlingBubble.js
+++ b/src/components/SeedlingBubble.js
@@ -15,6 +15,7 @@ export const SeedlingBubble = ({
   setPosition,
   onClick,
   syncPosition,
+  backgroundOnly = false,
 }) => {
   const [background, setBackground] = useState();
   const [isDragging, setDragging] = useState(false); // Initial value is false
@@ -52,6 +53,30 @@ export const SeedlingBubble = ({
     setDragStartPos(null); //reset the drag start to 0
     syncPosition();
   };
+
+  if (backgroundOnly) {
+    return (
+      <div
+        // React uses "className" instead of the normal "class" because "class" is already a reserved keyword
+        // in JavaScript with a different meaning.
+        className={styles.seedlingBubble}
+        style={{
+          top: y - size / 2, // We do the extra calculation because CSS is expecting top-left corner
+          left: x - size / 2, // instead of center for <div> elements
+          height: size,
+          width: size,
+          zIndex: isDragging ? 1000 : "auto", // move bubble to toppest layer when dragged
+        }}
+      >
+        <div
+          className={styles.gradientOutline}
+          style={{
+            background,
+          }}
+        />
+      </div>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
This takes @lunar-luna-dmn's goo effect filter and applies it across the app to make a gooey, sticky, blobby mess!

The secret is that I created new `div` containing a second, shadow copy of all the SeedlingBubbles, but suppressing the image and text and all the interactivity of these shadow SeedlingBubbles, and then applied the goo filter to that `div` container. Had to mess with some of the parameters to get it to look good.

Added `backgroundOnly` prop to `SeedlingBubble` component to get it to render only the gradient halo and none of the other stuff.

It's messy and a bit hacky but it works! In a future PR I can refactor this cause `App` is getting a bit too large and unwieldy.

<img width="1440" alt="Screenshot 2024-11-05 at 5 49 03 PM" src="https://github.com/user-attachments/assets/26206251-d06a-4594-a0f3-10e86185cc35">
